### PR TITLE
update Extempore link

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
 
   `Windows | macOS | GNU/Linux` `openFrameworks` `FLOSS` `visuals`
 
-- [Extempore](http://extempore.moso.com.au/) - (Previously [Impromptu](http://impromptu.moso.com.au/)) A programming language and runtime environment designed to support 'cyberphysical programming'.
+- [Extempore](https://extemporelang.github.io) - (Previously [Impromptu](http://impromptu.moso.com.au/)) A programming language and runtime environment designed to support 'cyberphysical programming'.
 
   `Windows | macOS | GNU/Linux` `lisp` `FLOSS` `audio`
 


### PR DESCRIPTION
Since the old `extempore.moso.com.au` link now redirects to `extemporelang.github.io` now anyway, I think it makes sense to cut out the middle-person :)