### PR TITLE
Add GLICOL, kilobeat and Web Audio Conference

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
 
   `Windows | macOS | GNU/Linux` `C++` `FLOSS` `audio`
   
-- [kilobeat](https://ijc8.me/2020/05/22/kilobeat/) - A collaborative web-based dsp livecoding instrument inspired by bytebeat and Gibber.
+- [kilobeat](https://ijc8.me/kilobeat) - A collaborative web-based dsp livecoding instrument inspired by bytebeat and Gibber.
 
   `Google Chrome | Mozilla Firefox` `web` `JavaScript` `FLOSS` `audio`
 

--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
 - [FARM](http://functional-art.org/) - Workshop on Functional Art, Music, Modeling, and Design.
 - [ICLI](http://www.liveinterfaces.org/) - International Conference on Live Interfaces.
 - [NIME](http://www.nime.org) - New Interfaces for Musical Expression conference.
-- [WAC](https://http://webaudioconf.com/) - The Web Audio Conference.
+- [WAC](https://webaudioconf.com/) - The Web Audio Conference.
 
 ## Related lists
 

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
 - [Gibber](http://charlie-roberts.com/gibber/) - Creative coding for JavaScript.
 
   `Google Chrome | Mozilla Firefox` `web` `JavaScript` `FLOSS` `audio` `visuals`
+  
+- [GLICOL](https://glicol.web.app/) - A graph-oriented live coding language written in Rust.
+
+  `Google Chrome | Mozilla Firefox` `web` `Rust` `JavaScript` `WebAssembly` `FLOSS` `audio` `visuals`
 
 - [Improviz](http://github.com/rumblesan/improviz) - An environment for using and abusing primitive shapes and animated textures.
 
@@ -109,6 +113,10 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
 - [i-score](http://www.i-score.org/) - An interactive sequencer that allows live programming of OSC-enabled applications, through a visual language and JavaScript scripting.
 
   `Windows | macOS | GNU/Linux` `C++` `FLOSS` `audio`
+  
+- [kilobeat](https://ijc8.me/2020/05/22/kilobeat/) - A collaborative web-based dsp livecoding instrument inspired by bytebeat and Gibber.
+
+  `Google Chrome | Mozilla Firefox` `web` `JavaScript` `FLOSS` `audio`
 
 - [Krill](https://github.com/Mdashdotdashn/krill) - Tidal cycle like live coding in NodeJS / Browser.
 
@@ -358,6 +366,7 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
 - [FARM](http://functional-art.org/) - Workshop on Functional Art, Music, Modeling, and Design.
 - [ICLI](http://www.liveinterfaces.org/) - International Conference on Live Interfaces.
 - [NIME](http://www.nime.org) - New Interfaces for Musical Expression conference.
+- [WAC](https://http://webaudioconf.com/) - The Web Audio Conference.
 
 ## Related lists
 


### PR DESCRIPTION
GLICOL is a brand new livecoding language written in Rust which has a browser-based IDE and runs on the AudioWorklet engine. kilobeat is a livecoding collaborative instrument inspired by bytebeat with some cool insteresting and recording features. The Web Audio Conference is addressing some topics related to live and creative coding (and where I first heard of GLICOL and kilobeat).