### PR TITLE
Add AREPL

### DIFF
--- a/README.md
+++ b/README.md
@@ -282,6 +282,7 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
 
 - [ANSIedad](https://github.com/gabochi/ANSIedad) - Generate visuals through a terminal emulator using ANSI escape codes.
 - [Arcadia](https://arcadia-unity.github.io/) - Live coding Clojure in Unity3D.
+- [Arepl](https://github.com/Almenon/AREPL-vscode) - Live coding Python in VSCode.
 - [Automationism](https://www.automatonism.com/) - A modular synthesiser that runs in the open source programming language Pure Data.
 - [blink](https://github.com/crosire/blink) - A library which allows you to edit source code of any Windows C++ project live at runtime.
 - [Bonzomatic](https://github.com/Gargaj/Bonzomatic) - GLSL and HLSL live coding environment, originally designed for live coding competitions at demoparties.


### PR DESCRIPTION
Can be used for music or visualizations as well as general-purpose live coding. For example, https://github.com/Almenon/AREPL-vscode/wiki/Using-Turtle