### PR TITLE
Add Cowbells

### DIFF
--- a/README.md
+++ b/README.md
@@ -289,6 +289,7 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
 - [CaosBox](https://github.com/josecaos/caosbox) - A non-common live coding and algorave sequencer written with SuperCollider.
 - [CHmUsiCK](https://github.com/essteban/CHmUsiCK) - Library to make ChucK a 'more algorave like' language.
 - [cl-collider](https://github.com/byulparan/cl-collider) - A SuperCollider client for CommonLisp.
+- [Cowbells](https://github.com/omkamra/cowbells) - A Clojure library for musical experimentation and live coding.
 - [dafxpipe](https://github.com/nwoeanhinnogaehr/dafxpipe) - Software for live coding audio effects and synths.
 - [diatonic](https://github.com/pd3v/diatonic) - Diatonic transforms for music making.
 - [disclojure](https://github.com/pjagielski/disclojure) - A live coding environment for Overtone and Leipzig.


### PR DESCRIPTION
Cowbells is a Clojure library which lets you live code FluidSynth from within a Clojure REPL.

Feature highlights:

- drives an in-process FluidSynth instance through the C API bound into the JVM via JNR-FFI
- notes can be represented by keywords (:c-3), MIDI note values or scale degrees
- supports any kind of scale (just give it the list of intervals)
- musical phrases can be encoded with either Clojure data structures or an equivalent text-based syntax
- musical phrases can be bound to variables for reuse in other phrases
- supports scoped change of scale, mode, root note, octave, semitone offset, MIDI channel, velocity, note step and duration
- supports live looping (in the sense of Extempore or Sonic Pi)
- the sequencer is pretty generic, it could be used to control anything, not just musical devices (e.g. it would be possible to play music and control an OpenGL visualizer via OSC simultaneously from the same patterns)
- there is a tutorial which can be followed in a Clojure-capable editor, with runnable examples