### PR TITLE
Update link to TimeLines

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
 
   `Windows | macOS | GNU/Linxux` `Haskell` `SuperCollider` `FLOSS` `audio`
 
-- [TimeLines](https://github.com/lnfiniteMonkeys/TimeLines) - A modular synthesizer for live coding the flow of time.
+- [TimeLines](https://github.com/lnfiniteMonkeys/TimeLines-hs) - A modular synthesizer for live coding the flow of time.
 
   `Windows | macOS | GNU/Linux` `FLOSS` `Haskell` `SuperCollider` `audio`
   


### PR DESCRIPTION
Looks like the repo has changed name from 'Timelines' to 'TimeLines-hs'. This commit adjusts the link to point to the new location of the repo.