### PR TITLE
Add trane to list of livecoding environments

### DIFF
--- a/README.md
+++ b/README.md
@@ -313,8 +313,11 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
 
 - [Topos](https://topos.live/) - Web-based live coding environment inspired by the Monome Teletype.
 
-
   `Google Chrome | Mozilla Firefox` `FLOSS` `Javascript` `audio` `midi`
+
+- [Trane](https://lisp.trane.studio) - Browser-based livecoding in Janet 
+
+  `Mozilla Firefox | Google Chrome` `web` `Janet` `MIDI` `audio` `WebAudio` `FOSS`
   
 - [Tweakable](https://tweakable.org/) - Visual programming for music, sound and video, used by artists and musicians to make interactive art and music on the web.
 


### PR DESCRIPTION
Trane is a WIP livecoding language for the browser. It's based on [Janet](https://janet-lang.org/), A lovely embeddable lispy language. 

For a tour of most of the features so far: https://lisp.trane.studio/?t=tracks/etude.janet

