### PR TITLE
Add `textmode.js` (browser-based textmode / ASCII visuals)

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,13 +319,17 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
 
   `FreeBSD | GNU/Linux` `Go` `audio` `synthesis` `FOSS`
 
+- [synth.textmode.art](https://synth.textmode.art/) - A web-based live coding environment combining textmode visuals with audio synthesis.
+
+  `web` `JavaScript` `audio` `visuals`
+
 - [synth-x](https://github.com/luiscript/synth-x) - An experimental live coding environment for making music created with modern web technologies. (inactive)
 
   `Windows | macOS | GNU/Linux` `JavaScript` `nodejs` `audio`
 
 - [textmode.js](https://code.textmode.art/) - A creative coding library for real-time textmode / ASCII graphics in the browser, suitable for generative art, interactive sketches, and live-coded visuals.
 
-  `web` `JavaScript` `FLOSS` `visuals`
+  `web` `JavaScript` `visuals`
   
 - [TEXTOR](https://adelfaure.net/tools/textor/) - Textor is a textmode editor and live-coding environement for visuals and sounds.
 

--- a/README.md
+++ b/README.md
@@ -323,7 +323,7 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
 
   `Windows | macOS | GNU/Linux` `JavaScript` `nodejs` `audio`
 
-- [textmode.js](https://code.textmode.art/) - A creative coding library for real-time textmode / ASCII graphics in the browser, usable standalone or integrated into live-coding environments like [flok.cc](https://flok.cc).
+- [textmode.js](https://code.textmode.art/) - A creative coding library for real-time textmode / ASCII graphics in the browser, suitable for generative art, interactive sketches, and live-coded visuals.
 
   `web` `JavaScript` `FLOSS` `visuals`
   

--- a/README.md
+++ b/README.md
@@ -449,6 +449,7 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
 - [Strudel Flow](https://xyflow.com/strudel-flow) - An experimental node-based UI for Strudel built with React Flow.
 - [Supriya](https://github.com/josiah-wolf-oberholtzer/supriya) - A Python API for SuperCollider.
 - [textmode.js](https://code.textmode.art/) - A creative coding library for real-time textmode / ASCII graphics in the browser, suitable for generative art, interactive sketches, and live-coded visuals.
+- [textmode.synth.js](https://github.com/humanbydefinition/textmode.synth.js) - A hydra-inspired visual synthesis plugin for textmode.js that drives procedural ASCII/textmode animations through a chainable, WebGL-powered API.
 - [tidal-autocode](https://atom.io/packages/tidal-autocode) - Auto-generates patterns for TidalCycles (requires [Atom](https://atom.io/) editor).
 - [tidal-chord](https://github.com/fp4me/tidal-chord) - An add-on to the amazing live coding project TidalCycles.
 - [TidalFX](https://github.com/calumgunn/TidalFX) - A haskell package adding weirder effects to Tidal from non-standard UGens.

--- a/README.md
+++ b/README.md
@@ -322,6 +322,10 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
 - [synth-x](https://github.com/luiscript/synth-x) - An experimental live coding environment for making music created with modern web technologies. (inactive)
 
   `Windows | macOS | GNU/Linux` `JavaScript` `nodejs` `audio`
+
+- [textmode.js](https://code.textmode.art/) - A creative coding library for real-time textmode / ASCII graphics in the browser, usable standalone or integrated into live-coding environments like [flok.cc](https://flok.cc).
+
+  `web` `JavaScript` `FLOSS` `visuals`
   
 - [TEXTOR](https://adelfaure.net/tools/textor/) - Textor is a textmode editor and live-coding environement for visuals and sounds.
 

--- a/README.md
+++ b/README.md
@@ -331,10 +331,6 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
 
   `Windows | macOS | GNU/Linux` `JavaScript` `nodejs` `audio`
 
-- [textmode.js](https://code.textmode.art/) - A creative coding library for real-time textmode / ASCII graphics in the browser, suitable for generative art, interactive sketches, and live-coded visuals.
-
-  `web` `JavaScript` `visuals`
-  
 - [TEXTOR](https://adelfaure.net/tools/textor/) - Textor is a textmode editor and live-coding environement for visuals and sounds.
 
   `Google Chrome | Mozilla Firefox` `web` `JavaScript` `FLOSS` `audio` `visuals`
@@ -452,6 +448,7 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
 - [sonic-pixels](https://github.com/emlyn/sonic-pixels) - Interactive lighting effects for Sonic Pi.
 - [Strudel Flow](https://xyflow.com/strudel-flow) - An experimental node-based UI for Strudel built with React Flow.
 - [Supriya](https://github.com/josiah-wolf-oberholtzer/supriya) - A Python API for SuperCollider.
+- [textmode.js](https://code.textmode.art/) - A creative coding library for real-time textmode / ASCII graphics in the browser, suitable for generative art, interactive sketches, and live-coded visuals.
 - [tidal-autocode](https://atom.io/packages/tidal-autocode) - Auto-generates patterns for TidalCycles (requires [Atom](https://atom.io/) editor).
 - [tidal-chord](https://github.com/fp4me/tidal-chord) - An add-on to the amazing live coding project TidalCycles.
 - [TidalFX](https://github.com/calumgunn/TidalFX) - A haskell package adding weirder effects to Tidal from non-standard UGens.


### PR DESCRIPTION
This PR adds **textmode.js** to the *Libraries* section.

textmode.js is a browser-based creative coding library for real-time textmode / ASCII graphics. It is not a live-coding–specific system, but its real-time rendering model makes it well suited for live-coded visual work.

In addition to live coding, textmode.js can be used for generative art, long-form visual sketches, and interactive works responding to mouse, keyboard, and touch input.

The library is also available inside the collaborative live coding environment [flok.cc](https://flok.cc), where it can be used in live coding contexts, such as rendering Hydra canvases through a textmode frame and creating audio-reactive visuals using audio information from Strudel panes.

More information and documentation: https://code.textmode.art/
