### PR TITLE
Remove repurposed Cyril website link

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Quoting [Wikipedia](https://en.wikipedia.org/wiki/Live_coding)
   
   `Windows | macOS | GNU/Linux` `Pharo`  `midi` `Open Sound Control` `FLOSS` `audio`
 
-- [Cyril](http://cyrilcode.com/) - A programming language designed for fast prototyping of visualisations and livecoding visuals. (inactive)
+- Cyril - A programming language designed for fast prototyping of visualisations and livecoding visuals. (inactive)
 
   `Windows | macOS | GNU/Linux` `openFrameworks` `FLOSS` `visuals`
 


### PR DESCRIPTION
Closes #142

## Summary
- remove the repurposed cyrilcode.com link from the inactive Cyril entry
- keep the language name, description, status, and metadata unchanged

## Verification
- confirmed the current domain serves unrelated content
- confirmed the repository contains no remaining cyrilcode.com reference
- awesome-lint baseline comparison: 39 existing errors and 8 warnings on both untouched master and this change, with no diagnostic on the changed line
- git diff --check